### PR TITLE
feat: GitHub Actions artifact アクションをv4に更新

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -127,7 +127,7 @@ jobs:
           echo "PKG_PATH=${PKG_STAGING}/${PKG_NAME}" >> $GITHUB_OUTPUT
       -
         name: "Artifact upload: tarball"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.package.outputs.PKG_NAME }}
           path: ${{ steps.package.outputs.PKG_PATH }}
@@ -205,7 +205,7 @@ jobs:
           echo "PKG_CONTENT_TYPE=${PKG_CONTENT_TYPE}" >> $GITHUB_OUTPUT
       -
         name: Download Release Asset
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         id: asset
         with:
           name: ${{ steps.package.outputs.PKG_NAME }}


### PR DESCRIPTION
## 概要
- Fixes #18: GitHub Actions の artifact 関連アクションを最新バージョン（v4）に更新

## 更新内容
- `actions/upload-artifact@v3` → `actions/upload-artifact@v4`
- `actions/download-artifact@v3` → `actions/download-artifact@v4`

## 更新理由
- **廃止対応**: v3は2025年1月30日に使用不可になる予定
- **パフォーマンス**: v4では最大90%の性能向上
- **セキュリティ**: 最新バージョンによるセキュリティ強化
- **新機能**: アーティファクトの即座ダウンロード対応

## 重要な変更点
- v4では隠しファイルがデフォルトで除外される
- アーティファクトがアップロード後すぐにダウンロード可能
- v3とv4間でアーティファクトの互換性なし（今回は新規なので影響なし）

## テスト計画
- [x] ワークフローの構文チェック
- [ ] 実際のリリース時のアーティファクト生成確認
- [ ] ダウンロード機能の正常動作確認

## 備考
- `actions/checkout@v4` は既に更新済みのため対象外

🤖 Generated with [Claude Code](https://claude.ai/code)