### PR TITLE
fix: CUIレイヤーのエラーハンドリング改善

### DIFF
--- a/src/commands/extract.rs
+++ b/src/commands/extract.rs
@@ -15,7 +15,12 @@ pub(crate) fn extract_daily_files(src: String, dst: String, dry_run: bool) -> Re
     extract_daily_files_with_config(&cfg, src, dst, dry_run)
 }
 
-fn extract_daily_files_with_config(cfg: &Config, src: String, dst: String, dry_run: bool) -> Result<()> {
+fn extract_daily_files_with_config(
+    cfg: &Config,
+    src: String,
+    dst: String,
+    dry_run: bool,
+) -> Result<()> {
     let dst_dir = convert_to_path(&dst);
     let mut date_dir_entries: Vec<DirEntry> = WalkDir::new(src)
         .into_iter()
@@ -67,7 +72,7 @@ fn extract_daily_files_with_config(cfg: &Config, src: String, dst: String, dry_r
             let should_delete = !dry_run;
             let message = format_delete_empty_dir_message(dry_run, &dirpath.to_string_lossy());
             println!("{}", message);
-            
+
             if should_delete {
                 std::fs::remove_dir(dirpath)?;
             }
@@ -101,25 +106,30 @@ fn format_delete_empty_dir_message(dry_run: bool, path: &str) -> String {
 mod tests {
     use super::*;
 
-
     #[test]
     fn test_format_delete_empty_dir_message_dry_run_false() {
         // gag なしのテスト：分離されたメッセージフォーマット関数をテスト
         let message = format_delete_empty_dir_message(false, "/test/path");
-        
+
         // dry_run=falseの場合、[dry_run]プレフィックスは含まれてはいけない
-        assert!(!message.contains("[dry_run]"), 
-                "Bug: dry_run=false should not show [dry_run] prefix, but got: {}", message);
+        assert!(
+            !message.contains("[dry_run]"),
+            "Bug: dry_run=false should not show [dry_run] prefix, but got: {}",
+            message
+        );
         assert_eq!(message, "delete empty direcotry: /test/path");
     }
-    
+
     #[test]
     fn test_format_delete_empty_dir_message_dry_run_true() {
         // dry_run=true の場合の動作確認
         let message = format_delete_empty_dir_message(true, "/test/path");
-        
-        assert!(message.contains("[dry_run]"), 
-                "dry_run=true should show [dry_run] prefix, but got: {}", message);
+
+        assert!(
+            message.contains("[dry_run]"),
+            "dry_run=true should show [dry_run] prefix, but got: {}",
+            message
+        );
         assert_eq!(message, "[dry_run] delete empty direcotry: /test/path");
     }
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -23,7 +23,7 @@ fn convert_to_path(path_str: &str) -> PathBuf {
 fn date_from_str(date_str: &str) -> Option<NaiveDate> {
     let date_regex = Regex::new(r"^(?P<y>\d{4})[/-]?(?P<m>\d{1,2})[/-]?(?P<d>\d{1,2})(_.*)?$")
         .expect("Fail to create regex instance.");
-    let Some(caps) = date_regex.captures(date_str) else {return None};
+    let caps = date_regex.captures(date_str)?;
 
     let date_str = format!("{:04}{:02}{:02}", &caps["y"], &caps["m"], &caps["d"]);
     NaiveDate::parse_from_str(&date_str, "%Y%m%d").ok()

--- a/src/commands/pack.rs
+++ b/src/commands/pack.rs
@@ -10,7 +10,9 @@ pub(crate) fn pack_daily_files(src: String, dst: String, dry_run: bool) -> Resul
         if entry.metadata()?.is_file() {
             if let Some(file_name) = entry.file_name().to_str() {
                 // 日次ディレクトリ作成のため、ファイルの接頭辞から日付データを作成する
-                let Some(date) = super::date_from_str(file_name) else {continue};
+                let Some(date) = super::date_from_str(file_name) else {
+                    continue;
+                };
 
                 // 日次ディレクトリにファイルを格納する
                 let new_dir_path = super::generate_new_dir_path_with_date(&dst_dir, &date, &cfg);

--- a/src/cui/mod.rs
+++ b/src/cui/mod.rs
@@ -1,6 +1,7 @@
 mod options;
 
 use self::options::{Commands, Opts};
+use anyhow::{Context, Result};
 use clap::Parser;
 
 #[derive(Debug, Clone)]
@@ -15,7 +16,7 @@ impl Cui {
         }
     }
 
-    pub(super) async fn process(&self) {
+    pub(super) async fn process(&self) -> Result<()> {
         match self.opts.command().clone() {
             Commands::CreateNewDailyReport(args) => {
                 println!("{:#?}", args);
@@ -25,19 +26,52 @@ impl Cui {
                     args.date,
                     args.dry_run,
                 )
-                .expect("Fail to create new daily report file.");
+                .with_context(|| "Failed to create new daily report file")?;
+                Ok(())
             }
             Commands::Pack(args) => {
                 println!("{:#?}", args);
                 crate::commands::pack_daily_files(args.src, args.dst, args.dry_run)
-                    .expect("Fail to pack daily files.");
+                    .with_context(|| "Failed to pack daily files")?;
+                Ok(())
             }
             Commands::Extract(args) => {
                 println!("{:#?}", args);
                 crate::commands::extract_daily_files(args.src, args.dst, args.dry_run)
-                    .expect("Fail to extract daily files.");
+                    .with_context(|| "Failed to extract daily files")?;
+                Ok(())
             }
-            Commands::Config => crate::commands::print_config(),
+            Commands::Config => {
+                crate::commands::print_config();
+                Ok(())
+            }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // テスト用のヘルパー関数
+    fn create_test_cui_with_config() -> Cui {
+        use crate::cui::options::{Commands, Opts};
+        Cui {
+            opts: Opts {
+                command: Commands::Config,
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn test_process_method_returns_result_ok_for_config() {
+        // process()メソッドがResult<(), anyhow::Error>を返すことを確認
+        let cui = create_test_cui_with_config();
+
+        // Config コマンドの場合は成功するはず
+        let result: Result<(), anyhow::Error> = cui.process().await;
+
+        // Config コマンドは正常に実行されるはず
+        assert!(result.is_ok());
     }
 }

--- a/src/cui/options.rs
+++ b/src/cui/options.rs
@@ -11,7 +11,7 @@ use clap::{Args, Parser, Subcommand};
 #[clap(propagate_version = true)]
 pub(crate) struct Opts {
     #[clap(subcommand)]
-    command: Commands,
+    pub(crate) command: Commands,
 }
 
 impl Opts {
@@ -21,7 +21,7 @@ impl Opts {
 }
 
 #[derive(Debug, Clone, Subcommand)]
-pub(super) enum Commands {
+pub(crate) enum Commands {
     /// 新規の日報ファイルを作成する
     CreateNewDailyReport(CreateNewDailyReportArgs),
     /// ファイルを日次ディレクトリ配下に格納する

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,9 @@
 mod commands;
 mod cui;
 
-pub async fn init() {
+use anyhow::Result;
+
+pub async fn init() -> Result<()> {
     let app = cui::Cui::new().await;
-    app.process().await;
+    app.process().await
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,7 @@
 #[tokio::main]
 async fn main() {
-    daily_file_mover::init().await;
+    if let Err(e) = daily_file_mover::init().await {
+        eprintln!("Error: {:#}", e);
+        std::process::exit(1);
+    }
 }


### PR DESCRIPTION
## Summary
Issue #9 で指摘されたCUIレイヤーでの `.expect()` を使用したエラーハンドリングの問題を解決しました。

### 主な変更点
- `src/cui/mod.rs:28,33,38` の `.expect()` を `.with_context()` + `?` オペレーターに置換
- `process()` メソッドの戻り値を `Result<(), anyhow::Error>` に変更  
- `main.rs` でユーザーフレンドリーなエラーメッセージ表示を追加
- CUIエラーハンドリングのテストを追加
- clippy警告の修正とコードフォーマットの統一

### 動作確認
**修正前**: panic による強制終了
```
thread 'main' panicked at 'Fail to pack daily files.'
```

**修正後**: 適切なエラーメッセージ
```
Error: Failed to pack daily files: No such file or directory (os error 2)
```

## Test plan
- [x] 正常動作の確認（`--help`, `config`コマンド）
- [x] エラーケースでのpanicが発生しないことを確認
- [x] 適切なエラーメッセージが表示されることを確認
- [x] 全テストの実行
- [x] clippy, cargo fmt の品質チェック

Fixes #9

🤖 Generated with [Claude Code](https://claude.ai/code)