### PR TITLE
test: プラットフォーム非依存のパステストに修正

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -118,7 +118,8 @@ mod tests {
 
         // ファイルパス作成
         let new_path = generate_new_file_path_with_date(&new_dir_path, file_name, &date, &cfg);
-        let expect_path = convert_to_path("C:\\dev\\sandbox\\20230501_test.txt");
+        // プラットフォーム非依存の期待値作成
+        let expect_path = new_dir_path.join("20230501_test.txt");
         assert_eq!(new_path, expect_path);
     }
 
@@ -133,7 +134,8 @@ mod tests {
 
         // ファイルパス作成
         let new_path = generate_new_file_path_with_date(&new_dir_path, file_name, &date, &cfg);
-        let expect_path = convert_to_path("C:\\dev\\sandbox\\20230401_test.txt");
+        // プラットフォーム非依存の期待値作成
+        let expect_path = new_dir_path.join("20230401_test.txt");
         assert_eq!(new_path, expect_path);
     }
 }


### PR DESCRIPTION
## Summary
パス区切り文字の不一致によるテスト失敗を解決しました。

### 問題の詳細
#20 のマージ後、Linux/macOS環境で以下の2つのテストが失敗していました：
- `commands::tests::ファイル名に日付接頭辞を持つのでリネームされない`  
- `commands::tests::ファイル名に日付接頭辞を持たないのでリネームされる`

**失敗の原因:**
```
left: "C:\\dev\\sandbox/20230401_test.txt"     # 実際の結果（混在した区切り文字）
right: "C:\\dev\\sandbox\\20230401_test.txt"   # 期待値（Windowsスタイル）
```

### 修正内容
ハードコードされたWindowsパス形式をプラットフォーム非依存の実装に変更：

**修正前:**
```rust
let expect_path = convert_to_path("C:\\dev\\sandbox\\20230401_test.txt");
```

**修正後:**
```rust
// プラットフォーム非依存の期待値作成
let expect_path = new_dir_path.join("20230401_test.txt");
```

## Test plan
- [x] 修正対象の2つのテストが通ることを確認
- [x] 全テスト（10個）が通ることを確認  
- [x] Linux/macOS/Windows全てで動作するクロスプラットフォーム対応

### 検証結果
```
running 10 tests
test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

## Related
- Related to #9 (CUIエラーハンドリング改善) 
- Follow-up to #20 (PR #20のマージ後に発見されたテスト問題)

🤖 Generated with [Claude Code](https://claude.ai/code)